### PR TITLE
ci: add hacbs-core-service pipeline

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -16,7 +16,7 @@ spec:
       value: "quay.io/redhat-appstudio/pull-request-builds:pvc-cleaner-{{revision}}"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
       persistentVolumeClaim:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -16,7 +16,7 @@ spec:
       value: "quay.io/redhat-appstudio/pull-request-builds:pvc-cleaner-{{revision}}"
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
+    bundle: quay.io/redhat-appstudio/quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
       persistentVolumeClaim:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -16,7 +16,7 @@ spec:
       value: 'quay.io/redhat-appstudio/pvc-cleaner:{{revision}}'
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/pvc-cleaner/infra-deployments?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build/pvc-cleaner/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/pvc-cleaner//infra-deployments?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build/pvc-cleaner/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,9 +14,12 @@ spec:
       value: "{{revision}}"
     - name: output-image
       value: 'quay.io/redhat-appstudio/pvc-cleaner:{{revision}}'
+    - name: infra-deployment-update-script
+      value: |
+        sed -i -e 's|\(https://github.com/redhat-appstudio/pvc-cleaner/infra-deployments?ref=\)\(.*\)|\1{{ revision }}|' -e 's/\(newTag: \).*/\1{{ revision }}/' components/build/pvc-cleaner/kustomization.yaml
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/build-templates-bundle:0866720a87aec4675074069cd16662d8e01237cf
+    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
       persistentVolumeClaim:


### PR DESCRIPTION
Update the pipelineRef bundle with hacbs-core-service-templates-bundle, which is an extension of hacbs, for core services of AppStudio/HACBS, allows creating MR in infra-deployments and also add the infra-deployment update script.